### PR TITLE
Add Jargon group ID field

### DIFF
--- a/data/jargons.json
+++ b/data/jargons.json
@@ -3,7 +3,7 @@
     "id": "group-1",
     "description": "Mathematical statistics measure of how one probability distribution is different from a second, reference probability distribution",
     "archived": false,
-    "terms": [
+    "jargons": [
       {
         "id": "group-1-jargon-1",
         "name": "kullback-leibler divergence",
@@ -22,7 +22,7 @@
     "id": "group-2",
     "description": "Statistics concepts referring to the quantity optimized in Variational Bayesian methods",
     "archived": false,
-    "terms": [
+    "jargons": [
       {
         "id": "group-2-jargon-1",
         "name": "elbo",
@@ -47,7 +47,7 @@
     "id": "group-3",
     "description": "Statistics concepts referring to the variables that are not directly observed, but rather inferred from other observed variables",
     "archived": false,
-    "terms": [
+    "jargons": [
       {
         "id": "group-3-jargon-1",
         "name": "hidden variable",
@@ -78,7 +78,7 @@
     "id": "group-4",
     "description": "Phenomenon in the statistical analysis of scientific experiment where an apparently significant observation may have actually arisen by chance",
     "archived": false,
-    "terms": [
+    "jargons": [
       {
         "id": "group-4-jargon-1",
         "name": "look elsewhere effect",
@@ -103,7 +103,7 @@
     "id": "group-5",
     "description": "Concept referring to the artificial data that can be created using statistical methods",
     "archived": false,
-    "terms": [
+    "jargons": [
       {
         "id": "group-5-jargon-1",
         "name": "mock data",
@@ -140,7 +140,7 @@
     "id": "group-6",
     "description": "Methods of estimating the coefficients of multiple-regression models in scenarios where independent variables are highly correlated",
     "archived": false,
-    "terms": [
+    "jargons": [
       {
         "id": "group-6-jargon-1",
         "name": "gaussian process regression",
@@ -171,7 +171,7 @@
     "id": "group-7",
     "description": "Concepts referring to the score of a given model with respect to a hypothetical location parameter",
     "archived": false,
-    "terms": [
+    "jargons": [
       {
         "id": "group-7-jargon-1",
         "name": "gradient log-density",
@@ -190,7 +190,7 @@
     "id": "group-8",
     "description": "Markov chain Monte Carlo method for obtaining a sequence of random samples which converge to being distributed according to a target probability distribution for which direct sampling is tough",
     "archived": false,
-    "terms": [
+    "jargons": [
       {
         "id": "group-8-jargon-1",
         "name": "hamiltonian monte-carlo",
@@ -209,7 +209,7 @@
     "id": "group-9",
     "description": "Markov chain Monte Carlo algorithm for obtaining a sequence of observations which are approximated from a specified multivariate probability distribution, when direct sampling is tough",
     "archived": false,
-    "terms": [
+    "jargons": [
       {
         "id": "group-9-jargon-1",
         "name": "gibbs sampling",
@@ -228,7 +228,7 @@
     "id": "group-10",
     "description": "Physics concepts referring to a small localized object to which can be ascribed several properties such as volume, density or mass",
     "archived": false,
-    "terms": [
+    "jargons": [
       {
         "id": "group-10-jargon-1",
         "name": "particle",
@@ -247,7 +247,7 @@
     "id": "group-11",
     "description": "Physics concepts referring to the path that a particle with mass follows through space as a function of time",
     "archived": false,
-    "terms": [
+    "jargons": [
       {
         "id": "group-11-jargon-1",
         "name": "particle path",
@@ -266,7 +266,7 @@
     "id": "group-12",
     "description": "Mathematical / Statistics measure of the distance between two probability distributions over a given metric space / region",
     "archived": false,
-    "terms": [
+    "jargons": [
       {
         "id": "group-12-jargon-1",
         "name": "earth movers distance",
@@ -285,7 +285,7 @@
     "id": "group-13",
     "description": "Concepts referring to the continuous probability distribution of the x-intercept of a ray issuing from (x0, y) with a uniformly distributed angle",
     "archived": false,
-    "terms": [
+    "jargons": [
       {
         "id": "group-13-jargon-1",
         "name": "breit-widgner distribution",
@@ -310,7 +310,7 @@
     "id": "group-14",
     "description": "Information theory / Statistics measure for the good fit of a statistical model to a sample of data given values for the unknown parameters",
     "archived": false,
-    "terms": [
+    "jargons": [
       {
         "id": "group-14-jargon-1",
         "name": "cross entropy",
@@ -329,7 +329,7 @@
     "id": "group-15",
     "description": "Machine learning / Statistics measure of the proportion of true positives that are correctly identified",
     "archived": false,
-    "terms": [
+    "jargons": [
       {
         "id": "group-15-jargon-1",
         "name": "recall",
@@ -348,7 +348,7 @@
     "id": "group-16",
     "description": "Statistics concepts referring to the discrete probability distribution that describes the possible results of a random variable taking one of the N possible categories, with each category probability separately specified",
     "archived": false,
-    "terms": [
+    "jargons": [
       {
         "id": "group-16-jargon-1",
         "name": "categorical distribution",
@@ -373,7 +373,7 @@
     "id": "group-17",
     "description": "Statistics concepts referring to the uncertainty coming from the unknowns that differ each time we run the same experiment",
     "archived": false,
-    "terms": [
+    "jargons": [
       {
         "id": "group-17-jargon-1",
         "name": "aleatoric uncertainty",
@@ -392,7 +392,7 @@
     "id": "group-18",
     "description": "Statistics concepts referring to the uncertainty coming from sources that one could in principle know, but in practice do not",
     "archived": false,
-    "terms": [
+    "jargons": [
       {
         "id": "group-18-jargon-1",
         "name": "epistemic uncertainty",
@@ -411,7 +411,7 @@
     "id": "group-19",
     "description": "Interdisciplinary field that uses scientific methods, processes, algorithms and systems to extract knowledge and insights from structure and unstructured data, applying them to a wide range of domains",
     "archived": false,
-    "terms": [
+    "jargons": [
       {
         "id": "group-19-jargon-1",
         "name": "data science",
@@ -430,7 +430,7 @@
     "id": "group-20",
     "description": "Mathematical transformation used to convert a particle theory into its respective field theory by linearizing the density operator and introducing an auxiliary scalar field",
     "archived": false,
-    "terms": [
+    "jargons": [
       {
         "id": "group-20-jargon-1",
         "name": "hubbard-stratonovich transformation",
@@ -449,7 +449,7 @@
     "id": "group-21",
     "description": "Measurement for the accuracy of probabilistic predictions. It is applicable to tasks in which predictions must assign probabilities to a set of mutually exclusive outcomes or classes",
     "archived": false,
-    "terms": [
+    "jargons": [
       {
         "id": "group-21-jargon-1",
         "name": "scoring rule",
@@ -474,7 +474,7 @@
     "id": "group-22",
     "description": "Statistics estimate computed from the observed data, referring to the range of values for an unknown parameter",
     "archived": false,
-    "terms": [
+    "jargons": [
       {
         "id": "group-22-jargon-1",
         "name": "confidence interval",
@@ -493,7 +493,7 @@
     "id": "group-23",
     "description": "Statistics / Physics concepts referring to the general technique for estimating properties of a particular distribution, while only having samples generated from a different distribution than the distribution of interest",
     "archived": false,
-    "terms": [
+    "jargons": [
       {
         "id": "group-23-jargon-1",
         "name": "importance sampling",
@@ -512,7 +512,7 @@
     "id": "group-24",
     "description": "Machine learning individual measurable property or characteristic of a phenomenon being observed",
     "archived": false,
-    "terms": [
+    "jargons": [
       {
         "id": "group-24-jargon-1",
         "name": "dataset features",
@@ -531,7 +531,7 @@
     "id": "group-25",
     "description": "Machine learning / Mathematics methods for efficiently computing the gradient of a function or operator in a numerical optimization problem",
     "archived": false,
-    "terms": [
+    "jargons": [
       {
         "id": "group-25-jargon-1",
         "name": "adjoint state method",
@@ -562,7 +562,7 @@
     "id": "group-26",
     "description": "Concepts referring to the neural networks using real-valued functions (those whose value depends only on the distance between the input and some fixed point)",
     "archived": false,
-    "terms": [
+    "jargons": [
       {
         "id": "group-26-jargon-1",
         "name": "kernel-machine with gaussian kernel",
@@ -581,7 +581,7 @@
     "id": "group-27",
     "description": "Bayesian Statistics concepts referring to the logarithmic of the probability distribution that would express one's beliefs about an uncertain quantity before some evidence is considered",
     "archived": false,
-    "terms": [
+    "jargons": [
       {
         "id": "group-27-jargon-1",
         "name": "log-prior",
@@ -600,7 +600,7 @@
     "id": "group-28",
     "description": "Mathematics process to decompose numerical values in order to reduce the complexity and influence of certain variables upon them",
     "archived": false,
-    "terms": [
+    "jargons": [
       {
         "id": "group-28-jargon-1",
         "name": "principal-component analysis",

--- a/data/jargons.json
+++ b/data/jargons.json
@@ -6,7 +6,7 @@
     "terms": [
       {
         "id": "group-1-jargon-1",
-        "name": "kullback–leibler divergence",
+        "name": "kullback-leibler divergence",
         "regex": "[Kk]ullback[- ][Ll]eibler divergence",
         "archived": false
       },
@@ -212,7 +212,7 @@
     "terms": [
       {
         "id": "group-9-jargon-1",
-        "name": "Gibbs sampling",
+        "name": "gibbs sampling",
         "regex": "[Gg]ibbs sampling",
         "archived": false
       },

--- a/data/jargons.json
+++ b/data/jargons.json
@@ -5,15 +5,15 @@
     "archived": false,
     "jargons": [
       {
-        "id": "group-1-jargon-1",
-        "name": "kullback-leibler divergence",
-        "regex": "[Kk]ullback[- ][Ll]eibler divergence",
+        "jargon_id": "group-1-jargon-1",
+        "jargon_term": "kullback-leibler divergence",
+        "jargon_regex": "[Kk]ullback[- ][Ll]eibler divergence",
         "archived": false
       },
       {
-        "id": "group-1-jargon-2",
-        "name": "relative entropy",
-        "regex": "[Rr]elative entropy",
+        "jargon_id": "group-1-jargon-2",
+        "jargon_term": "relative entropy",
+        "jargon_regex": "[Rr]elative entropy",
         "archived": false
       }
     ]
@@ -24,21 +24,21 @@
     "archived": false,
     "jargons": [
       {
-        "id": "group-2-jargon-1",
-        "name": "elbo",
-        "regex": "ELBO",
+        "jargon_id": "group-2-jargon-1",
+        "jargon_term": "elbo",
+        "jargon_regex": "ELBO",
         "archived": false
       },
       {
-        "id": "group-2-jargon-2",
-        "name": "evidence lower bound",
-        "regex": "[Ee]vidence lower bound",
+        "jargon_id": "group-2-jargon-2",
+        "jargon_term": "evidence lower bound",
+        "jargon_regex": "[Ee]vidence lower bound",
         "archived": false
       },
       {
-        "id": "group-2-jargon-3",
-        "name": "variational free energy",
-        "regex": "[Vv]ariational free energy",
+        "jargon_id": "group-2-jargon-3",
+        "jargon_term": "variational free energy",
+        "jargon_regex": "[Vv]ariational free energy",
         "archived": false
       }
     ]
@@ -49,27 +49,27 @@
     "archived": false,
     "jargons": [
       {
-        "id": "group-3-jargon-1",
-        "name": "hidden variable",
-        "regex": "[Hh]idden variable",
+        "jargon_id": "group-3-jargon-1",
+        "jargon_term": "hidden variable",
+        "jargon_regex": "[Hh]idden variable",
         "archived": false
       },
       {
-        "id": "group-3-jargon-2",
-        "name": "latent variable",
-        "regex": "[Ll]atent variable",
+        "jargon_id": "group-3-jargon-2",
+        "jargon_term": "latent variable",
+        "jargon_regex": "[Ll]atent variable",
         "archived": false
       },
       {
-        "id": "group-3-jargon-3",
-        "name": "monte-carlo truth",
-        "regex": "[Mm]onte[- ][Cc]arlo truth",
+        "jargon_id": "group-3-jargon-3",
+        "jargon_term": "monte-carlo truth",
+        "jargon_regex": "[Mm]onte[- ][Cc]arlo truth",
         "archived": false
       },
       {
-        "id": "group-3-jargon-4",
-        "name": "unobserved variable",
-        "regex": "[Uu]nobserved variable",
+        "jargon_id": "group-3-jargon-4",
+        "jargon_term": "unobserved variable",
+        "jargon_regex": "[Uu]nobserved variable",
         "archived": false
       }
     ]
@@ -80,21 +80,21 @@
     "archived": false,
     "jargons": [
       {
-        "id": "group-4-jargon-1",
-        "name": "look elsewhere effect",
-        "regex": "[Ll]ook elsewhere effect",
+        "jargon_id": "group-4-jargon-1",
+        "jargon_term": "look elsewhere effect",
+        "jargon_regex": "[Ll]ook elsewhere effect",
         "archived": false
       },
       {
-        "id": "group-4-jargon-2",
-        "name": "multiple testing",
-        "regex": "[Mm]ultiple testing",
+        "jargon_id": "group-4-jargon-2",
+        "jargon_term": "multiple testing",
+        "jargon_regex": "[Mm]ultiple testing",
         "archived": false
       },
       {
-        "id": "group-4-jargon-3",
-        "name": "trials factor",
-        "regex": "[Tt]rials factor",
+        "jargon_id": "group-4-jargon-3",
+        "jargon_term": "trials factor",
+        "jargon_regex": "[Tt]rials factor",
         "archived": false
       }
     ]
@@ -105,33 +105,33 @@
     "archived": false,
     "jargons": [
       {
-        "id": "group-5-jargon-1",
-        "name": "mock data",
-        "regex": "[Mm]ock data",
+        "jargon_id": "group-5-jargon-1",
+        "jargon_term": "mock data",
+        "jargon_regex": "[Mm]ock data",
         "archived": false
       },
       {
-        "id": "group-5-jargon-2",
-        "name": "pseudo-data",
-        "regex": "[Pp]seudo[- ]data",
+        "jargon_id": "group-5-jargon-2",
+        "jargon_term": "pseudo-data",
+        "jargon_regex": "[Pp]seudo[- ]data",
         "archived": false
       },
       {
-        "id": "group-5-jargon-3",
-        "name": "synthetic data",
-        "regex": "[Ss]ynthetic data",
+        "jargon_id": "group-5-jargon-3",
+        "jargon_term": "synthetic data",
+        "jargon_regex": "[Ss]ynthetic data",
         "archived": false
       },
       {
-        "id": "group-5-jargon-4",
-        "name": "toy monte carlo",
-        "regex": "[Tt]oy [Mm]onte[- ][Cc]arlo",
+        "jargon_id": "group-5-jargon-4",
+        "jargon_term": "toy monte carlo",
+        "jargon_regex": "[Tt]oy [Mm]onte[- ][Cc]arlo",
         "archived": false
       },
       {
-        "id": "group-5-jargon-5",
-        "name": "toymc",
-        "regex": "[Tt]oy[Mm][Cc]",
+        "jargon_id": "group-5-jargon-5",
+        "jargon_term": "toymc",
+        "jargon_regex": "[Tt]oy[Mm][Cc]",
         "archived": false
       }
     ]
@@ -142,27 +142,27 @@
     "archived": false,
     "jargons": [
       {
-        "id": "group-6-jargon-1",
-        "name": "gaussian process regression",
-        "regex": "[Gg]aussian process regression",
+        "jargon_id": "group-6-jargon-1",
+        "jargon_term": "gaussian process regression",
+        "jargon_regex": "[Gg]aussian process regression",
         "archived": false
       },
       {
-        "id": "group-6-jargon-2",
-        "name": "kernel ridge regression",
-        "regex": "[Kk]ernel ridge regression",
+        "jargon_id": "group-6-jargon-2",
+        "jargon_term": "kernel ridge regression",
+        "jargon_regex": "[Kk]ernel ridge regression",
         "archived": false
       },
       {
-        "id": "group-6-jargon-3",
-        "name": "kriging",
-        "regex": "[Kk]riging",
+        "jargon_id": "group-6-jargon-3",
+        "jargon_term": "kriging",
+        "jargon_regex": "[Kk]riging",
         "archived": false
       },
       {
-        "id": "group-6-jargon-4",
-        "name": "ridge regression",
-        "regex": "[Rr]idge regression",
+        "jargon_id": "group-6-jargon-4",
+        "jargon_term": "ridge regression",
+        "jargon_regex": "[Rr]idge regression",
         "archived": false
       }
     ]
@@ -173,15 +173,15 @@
     "archived": false,
     "jargons": [
       {
-        "id": "group-7-jargon-1",
-        "name": "gradient log-density",
-        "regex": "[Gg]radient log[- ]density",
+        "jargon_id": "group-7-jargon-1",
+        "jargon_term": "gradient log-density",
+        "jargon_regex": "[Gg]radient log[- ]density",
         "archived": false
       },
       {
-        "id": "group-7-jargon-2",
-        "name": "score function",
-        "regex": "[Ss]core function",
+        "jargon_id": "group-7-jargon-2",
+        "jargon_term": "score function",
+        "jargon_regex": "[Ss]core function",
         "archived": false
       }
     ]
@@ -192,15 +192,15 @@
     "archived": false,
     "jargons": [
       {
-        "id": "group-8-jargon-1",
-        "name": "hamiltonian monte-carlo",
-        "regex": "[Hh]amiltonian [Mm]onte[- ][Cc]arlo",
+        "jargon_id": "group-8-jargon-1",
+        "jargon_term": "hamiltonian monte-carlo",
+        "jargon_regex": "[Hh]amiltonian [Mm]onte[- ][Cc]arlo",
         "archived": false
       },
       {
-        "id": "group-8-jargon-2",
-        "name": "hybrid monte-carlo",
-        "regex": "[Hh]ybrid [Mm]onte[- ][Cc]arlo",
+        "jargon_id": "group-8-jargon-2",
+        "jargon_term": "hybrid monte-carlo",
+        "jargon_regex": "[Hh]ybrid [Mm]onte[- ][Cc]arlo",
         "archived": false
       }
     ]
@@ -211,15 +211,15 @@
     "archived": false,
     "jargons": [
       {
-        "id": "group-9-jargon-1",
-        "name": "gibbs sampling",
-        "regex": "[Gg]ibbs sampling",
+        "jargon_id": "group-9-jargon-1",
+        "jargon_term": "gibbs sampling",
+        "jargon_regex": "[Gg]ibbs sampling",
         "archived": false
       },
       {
-        "id": "group-9-jargon-2",
-        "name": "heat-bath",
-        "regex": "[Hh]eat[- ]?[Bb]ath",
+        "jargon_id": "group-9-jargon-2",
+        "jargon_term": "heat-bath",
+        "jargon_regex": "[Hh]eat[- ]?[Bb]ath",
         "archived": false
       }
     ]
@@ -230,15 +230,15 @@
     "archived": false,
     "jargons": [
       {
-        "id": "group-10-jargon-1",
-        "name": "particle",
-        "regex": "[Pp]article",
+        "jargon_id": "group-10-jargon-1",
+        "jargon_term": "particle",
+        "jargon_regex": "[Pp]article",
         "archived": false
       },
       {
-        "id": "group-10-jargon-2",
-        "name": "sample",
-        "regex": "[Ss]ample",
+        "jargon_id": "group-10-jargon-2",
+        "jargon_term": "sample",
+        "jargon_regex": "[Ss]ample",
         "archived": false
       }
     ]
@@ -249,15 +249,15 @@
     "archived": false,
     "jargons": [
       {
-        "id": "group-11-jargon-1",
-        "name": "particle path",
-        "regex": "[Pp]article path",
+        "jargon_id": "group-11-jargon-1",
+        "jargon_term": "particle path",
+        "jargon_regex": "[Pp]article path",
         "archived": false
       },
       {
-        "id": "group-11-jargon-2",
-        "name": "particle trajectory",
-        "regex": "[Pp]article trajectory",
+        "jargon_id": "group-11-jargon-2",
+        "jargon_term": "particle trajectory",
+        "jargon_regex": "[Pp]article trajectory",
         "archived": false
       }
     ]
@@ -268,15 +268,15 @@
     "archived": false,
     "jargons": [
       {
-        "id": "group-12-jargon-1",
-        "name": "earth movers distance",
-        "regex": "[Ee]arth[- ]movers distance",
+        "jargon_id": "group-12-jargon-1",
+        "jargon_term": "earth movers distance",
+        "jargon_regex": "[Ee]arth[- ]movers distance",
         "archived": false
       },
       {
-        "id": "group-12-jargon-2",
-        "name": "wasserstein distance",
-        "regex": "[Ww]asserstein distance",
+        "jargon_id": "group-12-jargon-2",
+        "jargon_term": "wasserstein distance",
+        "jargon_regex": "[Ww]asserstein distance",
         "archived": false
       }
     ]
@@ -287,21 +287,21 @@
     "archived": false,
     "jargons": [
       {
-        "id": "group-13-jargon-1",
-        "name": "breit-widgner distribution",
-        "regex": "[Bb]reit[- ][Ww]idgner distribution",
+        "jargon_id": "group-13-jargon-1",
+        "jargon_term": "breit-widgner distribution",
+        "jargon_regex": "[Bb]reit[- ][Ww]idgner distribution",
         "archived": false
       },
       {
-        "id": "group-13-jargon-2",
-        "name": "cauchy distribution",
-        "regex": "[Cc]auchy distribution",
+        "jargon_id": "group-13-jargon-2",
+        "jargon_term": "cauchy distribution",
+        "jargon_regex": "[Cc]auchy distribution",
         "archived": false
       },
       {
-        "id": "group-13-jargon-3",
-        "name": "lorentz distribution",
-        "regex": "[Ll]orentz distribution",
+        "jargon_id": "group-13-jargon-3",
+        "jargon_term": "lorentz distribution",
+        "jargon_regex": "[Ll]orentz distribution",
         "archived": false
       }
     ]
@@ -312,15 +312,15 @@
     "archived": false,
     "jargons": [
       {
-        "id": "group-14-jargon-1",
-        "name": "cross entropy",
-        "regex": "[Cc]ross entropy",
+        "jargon_id": "group-14-jargon-1",
+        "jargon_term": "cross entropy",
+        "jargon_regex": "[Cc]ross entropy",
         "archived": false
       },
       {
-        "id": "group-14-jargon-2",
-        "name": "log likelihood",
-        "regex": "[Ll]og[- ][Ll]ikelihood",
+        "jargon_id": "group-14-jargon-2",
+        "jargon_term": "log likelihood",
+        "jargon_regex": "[Ll]og[- ][Ll]ikelihood",
         "archived": false
       }
     ]
@@ -331,15 +331,15 @@
     "archived": false,
     "jargons": [
       {
-        "id": "group-15-jargon-1",
-        "name": "recall",
-        "regex": "[Rr]ecall",
+        "jargon_id": "group-15-jargon-1",
+        "jargon_term": "recall",
+        "jargon_regex": "[Rr]ecall",
         "archived": false
       },
       {
-        "id": "group-15-jargon-2",
-        "name": "sensitivity",
-        "regex": "[Ss]ensitivity",
+        "jargon_id": "group-15-jargon-2",
+        "jargon_term": "sensitivity",
+        "jargon_regex": "[Ss]ensitivity",
         "archived": false
       }
     ]
@@ -350,21 +350,21 @@
     "archived": false,
     "jargons": [
       {
-        "id": "group-16-jargon-1",
-        "name": "categorical distribution",
-        "regex": "[Cc]ategorical distribution",
+        "jargon_id": "group-16-jargon-1",
+        "jargon_term": "categorical distribution",
+        "jargon_regex": "[Cc]ategorical distribution",
         "archived": false
       },
       {
-        "id": "group-16-jargon-2",
-        "name": "multinomial distribution",
-        "regex": "[Mm]ultinomial distribution",
+        "jargon_id": "group-16-jargon-2",
+        "jargon_term": "multinomial distribution",
+        "jargon_regex": "[Mm]ultinomial distribution",
         "archived": false
       },
       {
-        "id": "group-16-jargon-3",
-        "name": "multinoulli distribution",
-        "regex": "[Mm]ultinoulli distribution",
+        "jargon_id": "group-16-jargon-3",
+        "jargon_term": "multinoulli distribution",
+        "jargon_regex": "[Mm]ultinoulli distribution",
         "archived": false
       }
     ]
@@ -375,15 +375,15 @@
     "archived": false,
     "jargons": [
       {
-        "id": "group-17-jargon-1",
-        "name": "aleatoric uncertainty",
-        "regex": "[Aa]leatoric[- ]uncertainty",
+        "jargon_id": "group-17-jargon-1",
+        "jargon_term": "aleatoric uncertainty",
+        "jargon_regex": "[Aa]leatoric[- ]uncertainty",
         "archived": false
       },
       {
-        "id": "group-17-jargon-2",
-        "name": "statistical uncertainty",
-        "regex": "[Ss]tatistical[- ]uncertainty",
+        "jargon_id": "group-17-jargon-2",
+        "jargon_term": "statistical uncertainty",
+        "jargon_regex": "[Ss]tatistical[- ]uncertainty",
         "archived": false
       }
     ]
@@ -394,15 +394,15 @@
     "archived": false,
     "jargons": [
       {
-        "id": "group-18-jargon-1",
-        "name": "epistemic uncertainty",
-        "regex": "[Ee]pistemic[- ]uncertainty",
+        "jargon_id": "group-18-jargon-1",
+        "jargon_term": "epistemic uncertainty",
+        "jargon_regex": "[Ee]pistemic[- ]uncertainty",
         "archived": false
       },
       {
-        "id": "group-18-jargon-2",
-        "name": "systematic uncertainty",
-        "regex": "[Ss]ystematic[- ]uncertainty",
+        "jargon_id": "group-18-jargon-2",
+        "jargon_term": "systematic uncertainty",
+        "jargon_regex": "[Ss]ystematic[- ]uncertainty",
         "archived": false
       }
     ]
@@ -413,15 +413,15 @@
     "archived": false,
     "jargons": [
       {
-        "id": "group-19-jargon-1",
-        "name": "data science",
-        "regex": "[Dd]ata [Ss]cience",
+        "jargon_id": "group-19-jargon-1",
+        "jargon_term": "data science",
+        "jargon_regex": "[Dd]ata [Ss]cience",
         "archived": false
       },
       {
-        "id": "group-19-jargon-2",
-        "name": "big data analytics",
-        "regex": "[Bb]ig [Dd]ata analytics",
+        "jargon_id": "group-19-jargon-2",
+        "jargon_term": "big data analytics",
+        "jargon_regex": "[Bb]ig [Dd]ata analytics",
         "archived": false
       }
     ]
@@ -432,15 +432,15 @@
     "archived": false,
     "jargons": [
       {
-        "id": "group-20-jargon-1",
-        "name": "hubbard-stratonovich transformation",
-        "regex": "[Hh]ubbard[- ][Ss]tratonovich transformation",
+        "jargon_id": "group-20-jargon-1",
+        "jargon_term": "hubbard-stratonovich transformation",
+        "jargon_regex": "[Hh]ubbard[- ][Ss]tratonovich transformation",
         "archived": false
       },
       {
-        "id": "group-20-jargon-2",
-        "name": "auxiliary field",
-        "regex": "[Aa]uxiliary field",
+        "jargon_id": "group-20-jargon-2",
+        "jargon_term": "auxiliary field",
+        "jargon_regex": "[Aa]uxiliary field",
         "archived": false
       }
     ]
@@ -451,21 +451,21 @@
     "archived": false,
     "jargons": [
       {
-        "id": "group-21-jargon-1",
-        "name": "scoring rule",
-        "regex": "[Ss]coring rule",
+        "jargon_id": "group-21-jargon-1",
+        "jargon_term": "scoring rule",
+        "jargon_regex": "[Ss]coring rule",
         "archived": false
       },
       {
-        "id": "group-21-jargon-2",
-        "name": "proper-scoring rule",
-        "regex": "[Pp]roper[- ]scoring rule",
+        "jargon_id": "group-21-jargon-2",
+        "jargon_term": "proper-scoring rule",
+        "jargon_regex": "[Pp]roper[- ]scoring rule",
         "archived": false
       },
       {
-        "id": "group-21-jargon-3",
-        "name": "loss function",
-        "regex": "[Ll]oss function",
+        "jargon_id": "group-21-jargon-3",
+        "jargon_term": "loss function",
+        "jargon_regex": "[Ll]oss function",
         "archived": false
       }
     ]
@@ -476,15 +476,15 @@
     "archived": false,
     "jargons": [
       {
-        "id": "group-22-jargon-1",
-        "name": "confidence interval",
-        "regex": "[Cc]onfidence[- ]interval",
+        "jargon_id": "group-22-jargon-1",
+        "jargon_term": "confidence interval",
+        "jargon_regex": "[Cc]onfidence[- ]interval",
         "archived": false
       },
       {
-        "id": "group-22-jargon-2",
-        "name": "confidence level",
-        "regex": "[Cc]onfidence[- ]level",
+        "jargon_id": "group-22-jargon-2",
+        "jargon_term": "confidence level",
+        "jargon_regex": "[Cc]onfidence[- ]level",
         "archived": false
       }
     ]
@@ -495,15 +495,15 @@
     "archived": false,
     "jargons": [
       {
-        "id": "group-23-jargon-1",
-        "name": "importance sampling",
-        "regex": "[Ii]mportance sampling",
+        "jargon_id": "group-23-jargon-1",
+        "jargon_term": "importance sampling",
+        "jargon_regex": "[Ii]mportance sampling",
         "archived": false
       },
       {
-        "id": "group-23-jargon-2",
-        "name": "reweighing",
-        "regex": "[Rr]eweighing",
+        "jargon_id": "group-23-jargon-2",
+        "jargon_term": "reweighing",
+        "jargon_regex": "[Rr]eweighing",
         "archived": false
       }
     ]
@@ -514,15 +514,15 @@
     "archived": false,
     "jargons": [
       {
-        "id": "group-24-jargon-1",
-        "name": "dataset features",
-        "regex": "[Dd]ataset[s]? feature",
+        "jargon_id": "group-24-jargon-1",
+        "jargon_term": "dataset features",
+        "jargon_regex": "[Dd]ataset[s]? feature",
         "archived": false
       },
       {
-        "id": "group-24-jargon-2",
-        "name": "dataset variables",
-        "regex": "[Dd]ataset[s]? variable",
+        "jargon_id": "group-24-jargon-2",
+        "jargon_term": "dataset variables",
+        "jargon_regex": "[Dd]ataset[s]? variable",
         "archived": false
       }
     ]
@@ -533,27 +533,27 @@
     "archived": false,
     "jargons": [
       {
-        "id": "group-25-jargon-1",
-        "name": "adjoint state method",
-        "regex": "[Aa]djoint[[- ]state]? method",
+        "jargon_id": "group-25-jargon-1",
+        "jargon_term": "adjoint state method",
+        "jargon_regex": "[Aa]djoint[[- ]state]? method",
         "archived": false
       },
       {
-        "id": "group-25-jargon-2",
-        "name": "back-propagation",
-        "regex": "[Bb]ack[- ]?propagation",
+        "jargon_id": "group-25-jargon-2",
+        "jargon_term": "back-propagation",
+        "jargon_regex": "[Bb]ack[- ]?propagation",
         "archived": false
       },
       {
-        "id": "group-25-jargon-3",
-        "name": "kelley-bryson method",
-        "regex": "[Kk]elley[- ][Bb]ryson method",
+        "jargon_id": "group-25-jargon-3",
+        "jargon_term": "kelley-bryson method",
+        "jargon_regex": "[Kk]elley[- ][Bb]ryson method",
         "archived": false
       },
       {
-        "id": "group-25-jargon-4",
-        "name": "reverse mode automatic differentiation",
-        "regex": "[Rr]everse[- ]mode automatic differentiation",
+        "jargon_id": "group-25-jargon-4",
+        "jargon_term": "reverse mode automatic differentiation",
+        "jargon_regex": "[Rr]everse[- ]mode automatic differentiation",
         "archived": false
       }
     ]
@@ -564,15 +564,15 @@
     "archived": false,
     "jargons": [
       {
-        "id": "group-26-jargon-1",
-        "name": "kernel-machine with gaussian kernel",
-        "regex": "[Kk]ernel[- ]machine with [Gg]aussian kernel",
+        "jargon_id": "group-26-jargon-1",
+        "jargon_term": "kernel-machine with gaussian kernel",
+        "jargon_regex": "[Kk]ernel[- ]machine with [Gg]aussian kernel",
         "archived": false
       },
       {
-        "id": "group-26-jargon-2",
-        "name": "rbf network",
-        "regex": "RBF network",
+        "jargon_id": "group-26-jargon-2",
+        "jargon_term": "rbf network",
+        "jargon_regex": "RBF network",
         "archived": false
       }
     ]
@@ -583,15 +583,15 @@
     "archived": false,
     "jargons": [
       {
-        "id": "group-27-jargon-1",
-        "name": "log-prior",
-        "regex": "[Ll]og[- ]prior",
+        "jargon_id": "group-27-jargon-1",
+        "jargon_term": "log-prior",
+        "jargon_regex": "[Ll]og[- ]prior",
         "archived": false
       },
       {
-        "id": "group-27-jargon-2",
-        "name": "regularizer",
-        "regex": "[Rr]egularizer",
+        "jargon_id": "group-27-jargon-2",
+        "jargon_term": "regularizer",
+        "jargon_regex": "[Rr]egularizer",
         "archived": false
       }
     ]
@@ -602,15 +602,15 @@
     "archived": false,
     "jargons": [
       {
-        "id": "group-28-jargon-1",
-        "name": "principal-component analysis",
-        "regex": "[Pp]rincipal[- ][Cc]omponent analysis",
+        "jargon_id": "group-28-jargon-1",
+        "jargon_term": "principal-component analysis",
+        "jargon_regex": "[Pp]rincipal[- ][Cc]omponent analysis",
         "archived": false
       },
       {
-        "id": "group-28-jargon-2",
-        "name": "proper-orthogonal decomposition",
-        "regex": "[Pp]roper[- ][Oo]rthogonal decomposition",
+        "jargon_id": "group-28-jargon-2",
+        "jargon_term": "proper-orthogonal decomposition",
+        "jargon_regex": "[Pp]roper[- ][Oo]rthogonal decomposition",
         "archived": false
       }
     ]

--- a/data/jargons.json
+++ b/data/jargons.json
@@ -5,12 +5,14 @@
     "archived": false,
     "jargons": [
       {
+        "group_id": "group-1",
         "jargon_id": "group-1-jargon-1",
         "jargon_term": "kullback-leibler divergence",
         "jargon_regex": "[Kk]ullback[- ][Ll]eibler divergence",
         "archived": false
       },
       {
+        "group_id": "group-1",
         "jargon_id": "group-1-jargon-2",
         "jargon_term": "relative entropy",
         "jargon_regex": "[Rr]elative entropy",
@@ -24,18 +26,21 @@
     "archived": false,
     "jargons": [
       {
+        "group_id": "group-2",
         "jargon_id": "group-2-jargon-1",
         "jargon_term": "elbo",
         "jargon_regex": "ELBO",
         "archived": false
       },
       {
+        "group_id": "group-2",
         "jargon_id": "group-2-jargon-2",
         "jargon_term": "evidence lower bound",
         "jargon_regex": "[Ee]vidence lower bound",
         "archived": false
       },
       {
+        "group_id": "group-2",
         "jargon_id": "group-2-jargon-3",
         "jargon_term": "variational free energy",
         "jargon_regex": "[Vv]ariational free energy",
@@ -49,24 +54,28 @@
     "archived": false,
     "jargons": [
       {
+        "group_id": "group-3",
         "jargon_id": "group-3-jargon-1",
         "jargon_term": "hidden variable",
         "jargon_regex": "[Hh]idden variable",
         "archived": false
       },
       {
+        "group_id": "group-3",
         "jargon_id": "group-3-jargon-2",
         "jargon_term": "latent variable",
         "jargon_regex": "[Ll]atent variable",
         "archived": false
       },
       {
+        "group_id": "group-3",
         "jargon_id": "group-3-jargon-3",
         "jargon_term": "monte-carlo truth",
         "jargon_regex": "[Mm]onte[- ][Cc]arlo truth",
         "archived": false
       },
       {
+        "group_id": "group-3",
         "jargon_id": "group-3-jargon-4",
         "jargon_term": "unobserved variable",
         "jargon_regex": "[Uu]nobserved variable",
@@ -80,18 +89,21 @@
     "archived": false,
     "jargons": [
       {
+        "group_id": "group-4",
         "jargon_id": "group-4-jargon-1",
         "jargon_term": "look elsewhere effect",
         "jargon_regex": "[Ll]ook elsewhere effect",
         "archived": false
       },
       {
+        "group_id": "group-4",
         "jargon_id": "group-4-jargon-2",
         "jargon_term": "multiple testing",
         "jargon_regex": "[Mm]ultiple testing",
         "archived": false
       },
       {
+        "group_id": "group-4",
         "jargon_id": "group-4-jargon-3",
         "jargon_term": "trials factor",
         "jargon_regex": "[Tt]rials factor",
@@ -105,30 +117,35 @@
     "archived": false,
     "jargons": [
       {
+        "group_id": "group-5",
         "jargon_id": "group-5-jargon-1",
         "jargon_term": "mock data",
         "jargon_regex": "[Mm]ock data",
         "archived": false
       },
       {
+        "group_id": "group-5",
         "jargon_id": "group-5-jargon-2",
         "jargon_term": "pseudo-data",
         "jargon_regex": "[Pp]seudo[- ]data",
         "archived": false
       },
       {
+        "group_id": "group-5",
         "jargon_id": "group-5-jargon-3",
         "jargon_term": "synthetic data",
         "jargon_regex": "[Ss]ynthetic data",
         "archived": false
       },
       {
+        "group_id": "group-5",
         "jargon_id": "group-5-jargon-4",
         "jargon_term": "toy monte carlo",
         "jargon_regex": "[Tt]oy [Mm]onte[- ][Cc]arlo",
         "archived": false
       },
       {
+        "group_id": "group-5",
         "jargon_id": "group-5-jargon-5",
         "jargon_term": "toymc",
         "jargon_regex": "[Tt]oy[Mm][Cc]",
@@ -142,24 +159,28 @@
     "archived": false,
     "jargons": [
       {
+        "group_id": "group-6",
         "jargon_id": "group-6-jargon-1",
         "jargon_term": "gaussian process regression",
         "jargon_regex": "[Gg]aussian process regression",
         "archived": false
       },
       {
+        "group_id": "group-6",
         "jargon_id": "group-6-jargon-2",
         "jargon_term": "kernel ridge regression",
         "jargon_regex": "[Kk]ernel ridge regression",
         "archived": false
       },
       {
+        "group_id": "group-6",
         "jargon_id": "group-6-jargon-3",
         "jargon_term": "kriging",
         "jargon_regex": "[Kk]riging",
         "archived": false
       },
       {
+        "group_id": "group-6",
         "jargon_id": "group-6-jargon-4",
         "jargon_term": "ridge regression",
         "jargon_regex": "[Rr]idge regression",
@@ -173,12 +194,14 @@
     "archived": false,
     "jargons": [
       {
+        "group_id": "group-7",
         "jargon_id": "group-7-jargon-1",
         "jargon_term": "gradient log-density",
         "jargon_regex": "[Gg]radient log[- ]density",
         "archived": false
       },
       {
+        "group_id": "group-7",
         "jargon_id": "group-7-jargon-2",
         "jargon_term": "score function",
         "jargon_regex": "[Ss]core function",
@@ -192,12 +215,14 @@
     "archived": false,
     "jargons": [
       {
+        "group_id": "group-8",
         "jargon_id": "group-8-jargon-1",
         "jargon_term": "hamiltonian monte-carlo",
         "jargon_regex": "[Hh]amiltonian [Mm]onte[- ][Cc]arlo",
         "archived": false
       },
       {
+        "group_id": "group-8",
         "jargon_id": "group-8-jargon-2",
         "jargon_term": "hybrid monte-carlo",
         "jargon_regex": "[Hh]ybrid [Mm]onte[- ][Cc]arlo",
@@ -211,12 +236,14 @@
     "archived": false,
     "jargons": [
       {
+        "group_id": "group-9",
         "jargon_id": "group-9-jargon-1",
         "jargon_term": "gibbs sampling",
         "jargon_regex": "[Gg]ibbs sampling",
         "archived": false
       },
       {
+        "group_id": "group-9",
         "jargon_id": "group-9-jargon-2",
         "jargon_term": "heat-bath",
         "jargon_regex": "[Hh]eat[- ]?[Bb]ath",
@@ -230,12 +257,14 @@
     "archived": false,
     "jargons": [
       {
+        "group_id": "group-10",
         "jargon_id": "group-10-jargon-1",
         "jargon_term": "particle",
         "jargon_regex": "[Pp]article",
         "archived": false
       },
       {
+        "group_id": "group-10",
         "jargon_id": "group-10-jargon-2",
         "jargon_term": "sample",
         "jargon_regex": "[Ss]ample",
@@ -249,12 +278,14 @@
     "archived": false,
     "jargons": [
       {
+        "group_id": "group-11",
         "jargon_id": "group-11-jargon-1",
         "jargon_term": "particle path",
         "jargon_regex": "[Pp]article path",
         "archived": false
       },
       {
+        "group_id": "group-11",
         "jargon_id": "group-11-jargon-2",
         "jargon_term": "particle trajectory",
         "jargon_regex": "[Pp]article trajectory",
@@ -268,12 +299,14 @@
     "archived": false,
     "jargons": [
       {
+        "group_id": "group-12",
         "jargon_id": "group-12-jargon-1",
         "jargon_term": "earth movers distance",
         "jargon_regex": "[Ee]arth[- ]movers distance",
         "archived": false
       },
       {
+        "group_id": "group-12",
         "jargon_id": "group-12-jargon-2",
         "jargon_term": "wasserstein distance",
         "jargon_regex": "[Ww]asserstein distance",
@@ -287,18 +320,21 @@
     "archived": false,
     "jargons": [
       {
+        "group_id": "group-13",
         "jargon_id": "group-13-jargon-1",
         "jargon_term": "breit-widgner distribution",
         "jargon_regex": "[Bb]reit[- ][Ww]idgner distribution",
         "archived": false
       },
       {
+        "group_id": "group-13",
         "jargon_id": "group-13-jargon-2",
         "jargon_term": "cauchy distribution",
         "jargon_regex": "[Cc]auchy distribution",
         "archived": false
       },
       {
+        "group_id": "group-13",
         "jargon_id": "group-13-jargon-3",
         "jargon_term": "lorentz distribution",
         "jargon_regex": "[Ll]orentz distribution",
@@ -312,12 +348,14 @@
     "archived": false,
     "jargons": [
       {
+        "group_id": "group-14",
         "jargon_id": "group-14-jargon-1",
         "jargon_term": "cross entropy",
         "jargon_regex": "[Cc]ross entropy",
         "archived": false
       },
       {
+        "group_id": "group-14",
         "jargon_id": "group-14-jargon-2",
         "jargon_term": "log likelihood",
         "jargon_regex": "[Ll]og[- ][Ll]ikelihood",
@@ -331,12 +369,14 @@
     "archived": false,
     "jargons": [
       {
+        "group_id": "group-15",
         "jargon_id": "group-15-jargon-1",
         "jargon_term": "recall",
         "jargon_regex": "[Rr]ecall",
         "archived": false
       },
       {
+        "group_id": "group-15",
         "jargon_id": "group-15-jargon-2",
         "jargon_term": "sensitivity",
         "jargon_regex": "[Ss]ensitivity",
@@ -350,18 +390,21 @@
     "archived": false,
     "jargons": [
       {
+        "group_id": "group-16",
         "jargon_id": "group-16-jargon-1",
         "jargon_term": "categorical distribution",
         "jargon_regex": "[Cc]ategorical distribution",
         "archived": false
       },
       {
+        "group_id": "group-16",
         "jargon_id": "group-16-jargon-2",
         "jargon_term": "multinomial distribution",
         "jargon_regex": "[Mm]ultinomial distribution",
         "archived": false
       },
       {
+        "group_id": "group-16",
         "jargon_id": "group-16-jargon-3",
         "jargon_term": "multinoulli distribution",
         "jargon_regex": "[Mm]ultinoulli distribution",
@@ -375,12 +418,14 @@
     "archived": false,
     "jargons": [
       {
+        "group_id": "group-17",
         "jargon_id": "group-17-jargon-1",
         "jargon_term": "aleatoric uncertainty",
         "jargon_regex": "[Aa]leatoric[- ]uncertainty",
         "archived": false
       },
       {
+        "group_id": "group-17",
         "jargon_id": "group-17-jargon-2",
         "jargon_term": "statistical uncertainty",
         "jargon_regex": "[Ss]tatistical[- ]uncertainty",
@@ -394,12 +439,14 @@
     "archived": false,
     "jargons": [
       {
+        "group_id": "group-18",
         "jargon_id": "group-18-jargon-1",
         "jargon_term": "epistemic uncertainty",
         "jargon_regex": "[Ee]pistemic[- ]uncertainty",
         "archived": false
       },
       {
+        "group_id": "group-18",
         "jargon_id": "group-18-jargon-2",
         "jargon_term": "systematic uncertainty",
         "jargon_regex": "[Ss]ystematic[- ]uncertainty",
@@ -413,12 +460,14 @@
     "archived": false,
     "jargons": [
       {
+        "group_id": "group-19",
         "jargon_id": "group-19-jargon-1",
         "jargon_term": "data science",
         "jargon_regex": "[Dd]ata [Ss]cience",
         "archived": false
       },
       {
+        "group_id": "group-19",
         "jargon_id": "group-19-jargon-2",
         "jargon_term": "big data analytics",
         "jargon_regex": "[Bb]ig [Dd]ata analytics",
@@ -432,12 +481,14 @@
     "archived": false,
     "jargons": [
       {
+        "group_id": "group-20",
         "jargon_id": "group-20-jargon-1",
         "jargon_term": "hubbard-stratonovich transformation",
         "jargon_regex": "[Hh]ubbard[- ][Ss]tratonovich transformation",
         "archived": false
       },
       {
+        "group_id": "group-20",
         "jargon_id": "group-20-jargon-2",
         "jargon_term": "auxiliary field",
         "jargon_regex": "[Aa]uxiliary field",
@@ -451,18 +502,21 @@
     "archived": false,
     "jargons": [
       {
+        "group_id": "group-21",
         "jargon_id": "group-21-jargon-1",
         "jargon_term": "scoring rule",
         "jargon_regex": "[Ss]coring rule",
         "archived": false
       },
       {
+        "group_id": "group-21",
         "jargon_id": "group-21-jargon-2",
         "jargon_term": "proper-scoring rule",
         "jargon_regex": "[Pp]roper[- ]scoring rule",
         "archived": false
       },
       {
+        "group_id": "group-21",
         "jargon_id": "group-21-jargon-3",
         "jargon_term": "loss function",
         "jargon_regex": "[Ll]oss function",
@@ -476,12 +530,14 @@
     "archived": false,
     "jargons": [
       {
+        "group_id": "group-22",
         "jargon_id": "group-22-jargon-1",
         "jargon_term": "confidence interval",
         "jargon_regex": "[Cc]onfidence[- ]interval",
         "archived": false
       },
       {
+        "group_id": "group-22",
         "jargon_id": "group-22-jargon-2",
         "jargon_term": "confidence level",
         "jargon_regex": "[Cc]onfidence[- ]level",
@@ -495,12 +551,14 @@
     "archived": false,
     "jargons": [
       {
+        "group_id": "group-23",
         "jargon_id": "group-23-jargon-1",
         "jargon_term": "importance sampling",
         "jargon_regex": "[Ii]mportance sampling",
         "archived": false
       },
       {
+        "group_id": "group-23",
         "jargon_id": "group-23-jargon-2",
         "jargon_term": "reweighing",
         "jargon_regex": "[Rr]eweighing",
@@ -514,12 +572,14 @@
     "archived": false,
     "jargons": [
       {
+        "group_id": "group-24",
         "jargon_id": "group-24-jargon-1",
         "jargon_term": "dataset features",
         "jargon_regex": "[Dd]ataset[s]? feature",
         "archived": false
       },
       {
+        "group_id": "group-24",
         "jargon_id": "group-24-jargon-2",
         "jargon_term": "dataset variables",
         "jargon_regex": "[Dd]ataset[s]? variable",
@@ -533,24 +593,28 @@
     "archived": false,
     "jargons": [
       {
+        "group_id": "group-25",
         "jargon_id": "group-25-jargon-1",
         "jargon_term": "adjoint state method",
         "jargon_regex": "[Aa]djoint[[- ]state]? method",
         "archived": false
       },
       {
+        "group_id": "group-25",
         "jargon_id": "group-25-jargon-2",
         "jargon_term": "back-propagation",
         "jargon_regex": "[Bb]ack[- ]?propagation",
         "archived": false
       },
       {
+        "group_id": "group-25",
         "jargon_id": "group-25-jargon-3",
         "jargon_term": "kelley-bryson method",
         "jargon_regex": "[Kk]elley[- ][Bb]ryson method",
         "archived": false
       },
       {
+        "group_id": "group-25",
         "jargon_id": "group-25-jargon-4",
         "jargon_term": "reverse mode automatic differentiation",
         "jargon_regex": "[Rr]everse[- ]mode automatic differentiation",
@@ -564,12 +628,14 @@
     "archived": false,
     "jargons": [
       {
+        "group_id": "group-26",
         "jargon_id": "group-26-jargon-1",
         "jargon_term": "kernel-machine with gaussian kernel",
         "jargon_regex": "[Kk]ernel[- ]machine with [Gg]aussian kernel",
         "archived": false
       },
       {
+        "group_id": "group-26",
         "jargon_id": "group-26-jargon-2",
         "jargon_term": "rbf network",
         "jargon_regex": "RBF network",
@@ -583,12 +649,14 @@
     "archived": false,
     "jargons": [
       {
+        "group_id": "group-27",
         "jargon_id": "group-27-jargon-1",
         "jargon_term": "log-prior",
         "jargon_regex": "[Ll]og[- ]prior",
         "archived": false
       },
       {
+        "group_id": "group-27",
         "jargon_id": "group-27-jargon-2",
         "jargon_term": "regularizer",
         "jargon_regex": "[Rr]egularizer",
@@ -602,12 +670,14 @@
     "archived": false,
     "jargons": [
       {
+        "group_id": "group-28",
         "jargon_id": "group-28-jargon-1",
         "jargon_term": "principal-component analysis",
         "jargon_regex": "[Pp]rincipal[- ][Cc]omponent analysis",
         "archived": false
       },
       {
+        "group_id": "group-28",
         "jargon_id": "group-28-jargon-2",
         "jargon_term": "proper-orthogonal decomposition",
         "jargon_regex": "[Pp]roper[- ][Oo]rthogonal decomposition",

--- a/schemas/defs/jargon-group.schema.json
+++ b/schemas/defs/jargon-group.schema.json
@@ -12,7 +12,7 @@
       "pattern": "^group-\\d+$"
     },
     "description": {
-      "description": "The concept all the contained jargon terms refers to",
+      "description": "The concept all the contained jargons refers to",
       "type": "string",
       "minLength": 0,
       "maxLength": 256
@@ -21,8 +21,8 @@
       "description": "Whether the group has been archived or not (soft delete)",
       "type": "boolean"
     },
-    "terms": {
-      "description": "The list of jargon terms contained in the group",
+    "jargons": {
+      "description": "The list of jargons contained in the group",
       "type": "array",
       "minItems": 2,
       "maxItems": 256,
@@ -33,5 +33,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["id", "description", "archived", "terms"]
+  "required": ["id", "description", "archived", "jargons"]
 }

--- a/schemas/defs/jargon.schema.json
+++ b/schemas/defs/jargon.schema.json
@@ -15,7 +15,8 @@
       "description": "The lower case name of the jargon term",
       "type": "string",
       "minLength": 2,
-      "maxLength": 64
+      "maxLength": 64,
+      "pattern": "^[a-z \\-]+$"
     },
     "regex": {
       "description": "The jargon term regex to consider every similar expression together",

--- a/schemas/defs/jargon.schema.json
+++ b/schemas/defs/jargon.schema.json
@@ -4,21 +4,21 @@
   "title": "Jargon",
   "type": "object",
   "properties": {
-    "id": {
+    "jargon_id": {
       "description": "The jargon ID",
       "type": "string",
       "minLength": 2,
       "maxLength": 32,
       "pattern": "^group-\\d+-jargon-\\d+$"
     },
-    "name": {
-      "description": "The lower case name of the jargon term",
+    "jargon_term": {
+      "description": "The jargon term in lower case",
       "type": "string",
       "minLength": 2,
       "maxLength": 64,
       "pattern": "^[a-z \\-]+$"
     },
-    "regex": {
+    "jargon_regex": {
       "description": "The jargon term regex to consider every similar expression together",
       "type": "string"
     },
@@ -28,5 +28,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["id", "name", "regex", "archived"]
+  "required": ["jargon_id", "jargon_term", "jargon_regex", "archived"]
 }

--- a/schemas/defs/jargon.schema.json
+++ b/schemas/defs/jargon.schema.json
@@ -4,6 +4,13 @@
   "title": "Jargon",
   "type": "object",
   "properties": {
+    "group_id": {
+      "description": "The jargon group ID",
+      "type": "string",
+      "minLength": 2,
+      "maxLength": 32,
+      "pattern": "^group-\\d+$"
+    },
     "jargon_id": {
       "description": "The jargon ID",
       "type": "string",
@@ -28,5 +35,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["jargon_id", "jargon_term", "jargon_regex", "archived"]
+  "required": ["group_id", "jargon_id", "jargon_term", "jargon_regex", "archived"]
 }


### PR DESCRIPTION
This PR makes the field `group_id` explicit to the Jargon schema and data records.

The whole purpose of this addition is to make the _DiffMessages_ coming from the usage of [jd](https://github.com/josephburnett/jd) in the CI jobs **auto-contained**. Without this field, the Jargon records would need to infer their `group_id` field from the `jargon_id`, leaving margin for bugs.

### Additional changes
- Renaming of JargonGroup schema field `terms`.
- Renaming of Jargon schema fields `id`, `term` and `regex`.
- Definition of a validation pattern for the `jargon_term` field.
- Correction of invalid characters for the `jargon_term` field of some data records (https://github.com/dialect-map/dialect-map-data/commit/81b8e4a1fbc680d86c2b1ef49f7ba488e033bd99).